### PR TITLE
Bootstrappify gomfweb template

### DIFF
--- a/cmd/gomfweb/main.go
+++ b/cmd/gomfweb/main.go
@@ -108,7 +108,7 @@ var tpl = template.Must(template.New("").Parse(`<!DOCTYPE html>
 
     <form method="get">
       <div class="form-group">
-        <label for"url">Enter a URL</label>
+        <label for="url">Enter a URL</label>
         <input name="url" type="url" placeholder="https://indieweb.org" class="form-control form-control-lg" />
       </div>
 

--- a/cmd/gomfweb/main.go
+++ b/cmd/gomfweb/main.go
@@ -145,9 +145,9 @@ var tpl = template.Must(template.New("").Parse(`<!DOCTYPE html>
         <li><a href="https://github.com/willnorris/microformats">Source code for the Microformats Go Parser</a></li>
         <li>
           Other Microformats Parser websites:
-          <a href="https://node.microformats.io">Node</a>,
+          <a href="http://node.microformats.io">Node</a>,
           <a href="https://php.microformats.io">PHP</a>,
-          <a href="https://python.microformats.io">Python</a>, and
+          <a href="http://python.microformats.io">Python</a>, and
           <a href="https://ruby.microformats.io">Ruby</a>.
         </li>
       </ul>

--- a/cmd/gomfweb/main.go
+++ b/cmd/gomfweb/main.go
@@ -87,44 +87,62 @@ func index(w http.ResponseWriter, r *http.Request) {
 	tpl.Execute(w, data)
 }
 
-var tpl = template.Must(template.New("").Parse(`<!doctype html>
+var tpl = template.Must(template.New("").Parse(`<!DOCTYPE html>
 <html>
 <head>
-<style>
-  input, textarea { font-size: 1rem; }
-  input[type=url], textarea { width: calc(100% - 1rem); }
-  input[type=url], textarea, pre { border: 1px solid #999; border-radius: 2px; padding: 0.5rem; }
-  label, input { display: block; }
-  input[type=submit] { margin: 0.5em 0; }
-  pre { background: #eee; }
-</style>
+  <title>Go Microformats Parser</title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+  <style>
+    form label { font-weight: bold; }
+    form textarea, form input[type=url] { font-family: "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    form .form-control:disabled { cursor: default; background: #efefef; color: black; }
+  </style>
 </head>
+
 <body>
-  <h1>go microformats parser</h1>
-  <h2>Parse a URL</h2>
-  <form method="GET">
-    <input name="url" type="url" placeholder="https://indieweb.org/" />
-    <input type="submit" value="Parse" />
-  </form>
+  <main class="container">
+    <h1 class="mt-5 mb-3">Microformats Parser (Go)</h1>
 
-  <h2>Parse HTML</h2>
-  <form method="POST">
-    <label for="html">HTML</label>
-    <textarea id="html" name="html" rows="15">{{ .HTML }}</textarea>
-    <label for="url">Base URL</label>
-    <input id="url" name="url" type="url" value="{{ .URL }}" placeholder="https://indieweb.org/" />
-    <input type="submit" value="Parse"/>
-  </form><br>
+    <form method="get">
+      <div class="form-group">
+        <label for"url">Enter a URL</label>
+        <input name="url" type="url" placeholder="https://indieweb.org" class="form-control form-control-lg" />
+      </div>
 
-{{ with .JSON }}
-  <h2>JSON</h2>
-  <pre><code>{{ . }}
-</code></pre>
-{{ end }}
-<ul>
-  <li><a href="http://microformats.org/wiki/about">About microformats</a></li>
-  <li><a href="https://github.com/willnorris/microformats/tree/master/cmd/gomfweb">Source code for this site</a></li>
-  <li><a href="http://microformats.org/wiki/microformats2#Parsers">Other microformats parsers</a></li>
-</ul>
+      <button type="submit" class="btn btn-lg btn-success">Parse</button>
+    </form>
+
+    <h2 class="h4 my-5">OR parse just a snippet of HTML</h2>
+
+    <form method="post" class="mb-5">
+      <div class="form-group">
+        <label for="html">HTML</label>
+        <textarea id="html" name="html" rows="6" class="form-control form-control-lg">{{ .HTML }}</textarea>
+      </div>
+
+      <div class="form-group">
+        <label for="base-url">Base URL</label>
+        <input id="base-url" name="base-url" type="url" value="{{ .URL }}" placeholder="https://indieweb.org" class="form-control form-control-lg" />
+      </div>
+
+      <button type="submit" class="btn btn-lg btn-success">Parse</button>
+    </form>
+
+    {{ with .JSON }}
+    <div class="form-group mb-5">
+      <label for="json">JSON</label>
+      <textarea id="json" name="json" rows="10" class="form-control form-control-lg" disabled="disabled">{{ . }}</textarea>
+    </div>
+    {{ end }}
+
+    <footer class="mb-5">
+      <ul>
+        <li><a href="http://microformats.org/wiki/about">About Microformats</a></li>
+        <li><a href="https://github.com/willnorris/microformats/tree/master/cmd/gomfweb">Source code for this site</a></li>
+        <li><a href="https://github.com/willnorris/microformats">Source code for the Microformats Go Parser</a></li>
+        <li><a href="http://microformats.org/wiki/microformats2#Parsers">Other microformats parsers</a></li>
+      </ul>
+    </footer>
+  </main>
 </body>
 </html>`))

--- a/cmd/gomfweb/main.go
+++ b/cmd/gomfweb/main.go
@@ -90,6 +90,9 @@ func index(w http.ResponseWriter, r *http.Request) {
 var tpl = template.Must(template.New("").Parse(`<!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
   <title>Go Microformats Parser</title>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
   <style>

--- a/cmd/gomfweb/main.go
+++ b/cmd/gomfweb/main.go
@@ -140,10 +140,16 @@ var tpl = template.Must(template.New("").Parse(`<!DOCTYPE html>
 
     <footer class="mb-5">
       <ul>
-        <li><a href="http://microformats.org/wiki/about">About Microformats</a></li>
+        <li><a href="https://microformats.io">About Microformats</a></li>
         <li><a href="https://github.com/willnorris/microformats/tree/master/cmd/gomfweb">Source code for this site</a></li>
         <li><a href="https://github.com/willnorris/microformats">Source code for the Microformats Go Parser</a></li>
-        <li><a href="http://microformats.org/wiki/microformats2#Parsers">Other microformats parsers</a></li>
+        <li>
+          Other Microformats Parser websites:
+          <a href="https://node.microformats.io">Node</a>,
+          <a href="https://php.microformats.io">PHP</a>,
+          <a href="https://python.microformats.io">Python</a>, and
+          <a href="https://ruby.microformats.io">Ruby</a>.
+        </li>
       </ul>
     </footer>
   </main>

--- a/cmd/gomfweb/main.go
+++ b/cmd/gomfweb/main.go
@@ -150,6 +150,7 @@ var tpl = template.Must(template.New("").Parse(`<!DOCTYPE html>
           <a href="http://python.microformats.io">Python</a>, and
           <a href="https://ruby.microformats.io">Ruby</a>.
         </li>
+	<li><a href="http://microformats.org/wiki/microformats2#Parsers">More Microformats parsers</a></li>
       </ul>
     </footer>
   </main>


### PR DESCRIPTION
Uses Bootstrap v4-alpha pulled from their CDN.