### PR TITLE
Implement urlincontent functionality

### DIFF
--- a/microformats.go
+++ b/microformats.go
@@ -99,7 +99,7 @@ func ParseNode(doc *html.Node, baseURL *url.URL) *Data {
 	return p.curData
 }
 
-func (p *parser) replaceHref(node *html.Node) {
+func (p *parser) expandHref(node *html.Node) {
 	if isAtom(node, atom.A) {
 		href := getAttrPtr(node, "href")
 		if href != nil {
@@ -123,7 +123,7 @@ func (p *parser) replaceHref(node *html.Node) {
 	}
 
 	for c := node.FirstChild; c != nil; c = c.NextSibling {
-		p.replaceHref(c)
+		p.expandHref(c)
 	}
 }
 
@@ -280,7 +280,7 @@ func (p *parser) walk(node *html.Node) {
 				var buf bytes.Buffer
 
 				for c := node.FirstChild; c != nil; c = c.NextSibling {
-					p.replaceHref(c)
+					p.expandHref(c)
 					html.Render(&buf, c)
 				}
 

--- a/microformats.go
+++ b/microformats.go
@@ -99,6 +99,7 @@ func ParseNode(doc *html.Node, baseURL *url.URL) *Data {
 	return p.curData
 }
 
+// expandHref expands relative URLs in a.href and img.src attributes to be absolute URLs.
 func (p *parser) expandHref(node *html.Node) {
 	if isAtom(node, atom.A) {
 		href := getAttrPtr(node, "href")

--- a/microformats.go
+++ b/microformats.go
@@ -285,6 +285,9 @@ func (p *parser) walk(node *html.Node) {
 				}
 
 				htmlbody = strings.Replace(buf.String(), "/>", " />", -1)
+				htmlbody = strings.TrimRightFunc(htmlbody, func(r rune) bool {
+					return r == ' '
+				})
 			case "dt":
 				if value == nil {
 					value = getDateTimeValue(node)

--- a/testsuite_test.go
+++ b/testsuite_test.go
@@ -40,7 +40,6 @@ import (
 // skip the tests which we don't pass yet
 var skipTests = []string{
 	"microformats-v2/h-entry/summarycontent",
-	"microformats-v2/h-entry/urlincontent",
 	"microformats-v2/h-event/concatenate",
 	"microformats-v2/h-event/dates",
 	"microformats-v2/h-feed/implied-title",


### PR DESCRIPTION
- This adds the functionality to replace "href" and "src" attributes in
  "e-content" with the absolute urls.

- The problem is that I don't know how to adjust the code, so it adds the 4 spaces at the end of the htmlBody to make the test pass. Removing the space in frontend the last </div> will make the test pass.
- This also appears for the self-closing tag of the img element, where the test expects a space before />. The go html renderer doesn't add this space.