### PR TITLE
Keep the count of the inner nested microformats

### DIFF
--- a/testsuite_test.go
+++ b/testsuite_test.go
@@ -49,8 +49,6 @@ var skipTests = []string{
 	"microformats-v2/h-entry/impliedvalue-nested",
 	"microformats-v2/h-entry/summarycontent",
 	"microformats-v2/h-event/concatenate",
-	"microformats-v2/h-feed/implied-title",
-	"microformats-v2/h-feed/simple",
 	"microformats-v2/h-geo/abbrpattern",
 	"microformats-v2/h-geo/hidden",
 	"microformats-v2/h-geo/valuetitleclass",


### PR DESCRIPTION
If the count == 0, there are no nested microformats and then use the implied name.