### PR TITLE
fix: avoid panics in ParseNode()

### DIFF
--- a/microformats.go
+++ b/microformats.go
@@ -118,6 +118,9 @@ func Parse(r io.Reader, baseURL *url.URL) *Data {
 // ParseNode parses the microformats found in doc.  baseURL is the URL this
 // document was retrieved from and is used to resolve any relative URLs.
 func ParseNode(doc *html.Node, baseURL *url.URL) *Data {
+	if doc == nil { // makes no sense to go further
+		return nil
+	}
 	p := new(parser)
 	p.curData = &Data{
 		Items:   make([]*Microformat, 0),
@@ -125,6 +128,9 @@ func ParseNode(doc *html.Node, baseURL *url.URL) *Data {
 		RelURLs: make(map[string]*RelURL),
 	}
 	p.base = baseURL
+	if p.base == nil { // can make sense if base can be inferred from contents
+		p.base = &url.URL{}
+	}
 	p.baseFound = false
 	p.root = doc
 	p.walk(doc)

--- a/microformats.go
+++ b/microformats.go
@@ -108,15 +108,18 @@ type parser struct {
 }
 
 // Parse the microformats found in the HTML document read from r.  baseURL is
-// the URL this document was retrieved from and is used to resolve any
-// relative URLs.
+// the URL this document was retrieved from and is used to expand any
+// relative URLs.  If baseURL is nil and the base URL is not referenced in the
+// document, relative URLs are not expanded.
 func Parse(r io.Reader, baseURL *url.URL) *Data {
 	doc, _ := html.Parse(r)
 	return ParseNode(doc, baseURL)
 }
 
 // ParseNode parses the microformats found in doc.  baseURL is the URL this
-// document was retrieved from and is used to resolve any relative URLs.
+// document was retrieved from and is used to expand any relative URLs. If
+// baseURL is nil and the base URL is not referenced in the document,
+// relative URLs are not expanded.
 func ParseNode(doc *html.Node, baseURL *url.URL) *Data {
 	if doc == nil { // makes no sense to go further
 		return nil

--- a/microformats_test.go
+++ b/microformats_test.go
@@ -563,18 +563,21 @@ func Test_GetFirstPropValue(t *testing.T) {
 }
 
 func Test_ParseNodeNil(t *testing.T) {
-	tests := map[string]string{
-		"absolute": "<html><head><base href=\"https://example.com\"></head></html>",
-		"relative": "<html><head><base href=\"./something\"></head></html>",
-		"none":     "<html><head></head></html>", // parseNode(tt) == nil
+	tests := []struct {
+		name string
+		html string
+	}{
+		{"absolute", "<html><head><base href=\"https://example.com\"></head></html>"},
+		{"relative", "<html><head><base href=\"./something\"></head></html>"},
+		{"none", "<html><head></head></html>"}, // parseNode(tt.html) == nil
 	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			n, err := parseNode(tt)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, err := parseNode(tt.html)
 			if err != nil {
 				t.Fatalf("Error parsing HTML: %v", err)
 			}
-			ParseNode(n, nil)
+			ParseNode(n, nil) // this should not panic
 		})
 	}
 }

--- a/microformats_test.go
+++ b/microformats_test.go
@@ -561,3 +561,20 @@ func Test_GetFirstPropValue(t *testing.T) {
 		}
 	}
 }
+
+func Test_ParseNodeNil(t *testing.T) {
+	tests := map[string]string{
+		"absolute": "<html><head><base href=\"https://example.com\"></head></html>",
+		"relative": "<html><head><base href=\"./something\"></head></html>",
+		"none":     "<html><head></head></html>", // parseNode(tt) == nil
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			n, err := parseNode(tt)
+			if err != nil {
+				t.Fatalf("Error parsing HTML: %v", err)
+			}
+			ParseNode(n, nil)
+		})
+	}
+}


### PR DESCRIPTION
this fixes #20 

`ParseNode(node, nil)` should be able to avoid panic even if `node` does not contain a valid absolute base path in its `<head>`, since there can be usable microformats with absolute paths or no paths.

`ParseNode(nil, base)` should return `nil` instead of panic, because why panic?