### PR TITLE
feat(ptd): add support for new types

### DIFF
--- a/ptd/ptd.go
+++ b/ptd/ptd.go
@@ -22,8 +22,9 @@ func PostType(item *microformats.Microformat) string {
 	}
 
 	for _, t := range item.Type {
-		if t == "h-event" {
-			return "event"
+		switch t {
+		case "h-event", "h-recipe", "h-review":
+			return t[2:]
 		}
 	}
 
@@ -32,8 +33,14 @@ func PostType(item *microformats.Microformat) string {
 		return t
 	}
 
+	if _, ok := item.Properties["checkin"]; ok {
+		return "checkin"
+	}
 	if validURL(item.Properties["video"]) {
 		return "video"
+	}
+	if validURL(item.Properties["audio"]) {
+		return "audio"
 	}
 	if validURL(item.Properties["photo"]) {
 		return "photo"
@@ -104,6 +111,12 @@ func ResponseType(item *microformats.Microformat) string {
 	}
 	if validURL(item.Properties["in-reply-to"]) {
 		return "reply"
+	}
+	if validURL(item.Properties["bookmark-of"]) {
+		return "bookmark"
+	}
+	if _, ok := item.Properties["follow-of"]; ok {
+		return "follow"
 	}
 
 	return "mention"

--- a/ptd/ptd_test.go
+++ b/ptd/ptd_test.go
@@ -23,9 +23,20 @@ func Test_NilItems(t *testing.T) {
 }
 
 func Test_PostType_Type(t *testing.T) {
-	item := &microformats.Microformat{Type: []string{"h-event"}}
-	if got, want := PostType(item), "event"; got != want {
-		t.Errorf("ResponseType(%v) returned %q, want %q", item, got, want)
+	tests := []struct {
+		typ  string
+		want string
+	}{
+		{"h-event", "event"},
+		{"h-recipe", "recipe"},
+		{"h-review", "review"},
+	}
+
+	for _, tt := range tests {
+		item := &microformats.Microformat{Type: []string{tt.typ}}
+		if got, want := PostType(item), tt.want; got != want {
+			t.Errorf("ResponseType(%v) returned %q, want %q", item, got, want)
+		}
 	}
 }
 
@@ -58,7 +69,11 @@ func Test_PostType_Properties(t *testing.T) {
 		{pm{"in-reply-to": {}}, "note"},
 		{pm{"in-reply-to": {""}}, "note"},
 		{pm{"in-reply-to": {"foo"}}, "reply"},
+		{pm{"bookmark-of": {"foo"}}, "bookmark"},
+		{pm{"follow-of": {"foo"}}, "follow"},
+		{pm{"checkin": {"foo"}}, "checkin"},
 		{pm{"video": {"foo"}}, "video"},
+		{pm{"audio": {"foo"}}, "audio"},
 		{pm{"photo": {"foo"}}, "photo"},
 
 		// content and name variations


### PR DESCRIPTION
Adds the post type discovery algorithm to this package. I have it in [my library](https://github.com/hacdias/indielib), but I think that it might fit here better since its... Microformats. It is a slightly augmented version compared to the original, as it checks for other post types too.

--

Thanks @nekr0z for asking me I had thought about making a PR here.