### PR TITLE
gomfweg: upgrade the Bootstrap version and align page with other parser pages

### DIFF
--- a/cmd/gomfweb/index.html
+++ b/cmd/gomfweb/index.html
@@ -59,7 +59,8 @@
                 name="html"
                 rows="6"
                 class="form-control form-control-lg font-monospace"
-              >{{ .HTML }}</textarea>
+              >
+{{ .HTML }}</textarea>
             </div>
 
             <div class="mb-3">
@@ -91,7 +92,8 @@
             rows="10"
             class="form-control form-control-lg font-monospace"
             disabled="disabled"
-          >{{ . }}</textarea>
+          >
+{{ . }}</textarea>
         </section>
         {{ end }}
 

--- a/cmd/gomfweb/index.html
+++ b/cmd/gomfweb/index.html
@@ -119,7 +119,7 @@
           </li>
           <li class="col-xl-6 order-xl-2">
             <a
-              href="https://github.com/microformats/microformats-parser-website-go"
+              href="https://github.com/willnorris/microformats/tree/main/cmd/gomfweb"
               >Source code for this site</a
             >
           </li>
@@ -127,6 +127,7 @@
             <a href="https://github.com/willnorris/microformats"
               >Source code for the Microformats Go Parser</a
             >
+            <span class="badge text-bg-light">v{{ .LibVersion }}</span>
           </li>
           <li id="parser-list" class="col-xl-6 order-xl-3">
             Other Microformats Parser websites:

--- a/cmd/gomfweb/index.html
+++ b/cmd/gomfweb/index.html
@@ -1,70 +1,171 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
 
-  <title>Go Microformats Parser</title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" 
-      integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
-  <style>
-    form label { font-weight: bold; }
-    form textarea, form input[type=url] { font-family: "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
-    form .form-control:disabled { cursor: default; background: #efefef; color: black; }
-  </style>
-</head>
+    <title>Go Microformats Parser</title>
 
-<body>
-  <main class="container">
-    <h1 class="mt-5 mb-3">Microformats Parser (Go)</h1>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="icon"
+      href="https://microformats.io/assets/images/microformats-logo.svg"
+      type="image/svg+xml"
+    />
+  </head>
 
-    <form method="get">
-      <div class="form-group">
-        <label for="url">Enter a URL</label>
-        <input name="url" type="url" placeholder="https://indieweb.org" class="form-control form-control-lg" />
-      </div>
+  <body>
+    <div class="container">
+      <h1 class="mt-5 mb-3">Microformats Parser (Go)</h1>
 
-      <button type="submit" class="btn btn-lg btn-success">Parse</button>
-    </form>
+      <main>
+        <section class="mb-5">
+          <h2 class="h4">Parse a URL</h2>
 
-    <h2 class="h4 my-5">OR parse just a snippet of HTML</h2>
+          <form action="/" accept-charset="UTF-8" method="get">
+            <div class="mb-3">
+              <label for="url" class="form-label fw-bold">Enter a URL</label>
+              <input
+                required
+                id="url"
+                class="form-control form-control-lg font-monospace"
+                type="url"
+                name="url"
+                placeholder="https://example.com/person.html"
+              />
+            </div>
 
-    <form method="post" class="mb-5">
-      <div class="form-group">
-        <label for="html">HTML</label>
-        <textarea id="html" name="html" rows="6" class="form-control form-control-lg">{{ .HTML }}</textarea>
-      </div>
+            <button type="submit" class="btn btn-lg btn-success">Parse</button>
+          </form>
+        </section>
 
-      <div class="form-group">
-        <label for="base-url">Base URL</label>
-        <input id="base-url" name="base-url" type="url" value="{{ .URL }}" placeholder="https://indieweb.org" class="form-control form-control-lg" />
-      </div>
+        <section class="mb-5">
+          <h2 class="h4 mb-5">OR parse just a snippet of HTML</h2>
 
-      <button type="submit" class="btn btn-lg btn-success">Parse</button>
-    </form>
+          <form method="post" action="/">
+            <div class="mb-3">
+              <label for="html" class="form-label fw-bold">HTML</label>
+              <textarea
+                required
+                id="html"
+                name="html"
+                rows="6"
+                class="form-control form-control-lg font-monospace"
+              >{{ .HTML }}</textarea>
+            </div>
 
-    {{ with .JSON }}
-    <div class="form-group mb-5">
-      <label for="json">JSON</label>
-      <textarea id="json" name="json" rows="10" class="form-control form-control-lg" disabled="disabled">{{ . }}</textarea>
+            <div class="mb-3">
+              <label for="base-url" class="form-label fw-bold"
+                >Base URL
+                <span class="fw-normal text-body-secondary"
+                  >(Optional)</span
+                ></label
+              >
+              <input
+                id="base-url"
+                name="url"
+                type="url"
+                value="{{ .URL }}"
+                class="form-control form-control-lg font-monospace"
+              />
+            </div>
+
+            <button type="submit" class="btn btn-lg btn-success">Parse</button>
+          </form>
+        </section>
+
+        {{ with .JSON }}
+        <section class="mb-5">
+          <label for="json" class="form-label fw-bold">JSON</label>
+          <textarea
+            id="json"
+            name="json"
+            rows="10"
+            class="form-control form-control-lg font-monospace"
+            disabled="disabled"
+          >{{ . }}</textarea>
+        </section>
+        {{ end }}
+
+        <section class="card mb-5">
+          <div class="card-body">
+            <h2 class="h4 card-title">Bookmarklet</h2>
+            <p class="card-text">
+              Drag this link to your bookmarks toolbar to parse a page with one
+              click!
+            </p>
+            <a
+              class="btn btn-primary btn-sm"
+              href="javascript:(function(){document.location.href='https://go.microformats.io/?url='+encodeURIComponent(document.location.href);}())"
+              onclick="event.preventDefault()"
+              >mf2 parser</a
+            >
+          </div>
+        </section>
+      </main>
+
+      <footer class="my-5">
+        <ul class="d-xl-flex flex-xl-wrap">
+          <li class="col-xl-6 order-xl-1">
+            <a href="https://microformats.io">About Microformats</a>
+          </li>
+          <li class="col-xl-6 order-xl-2">
+            <a
+              href="https://github.com/microformats/microformats-parser-website-go"
+              >Source code for this site</a
+            >
+          </li>
+          <li class="col-xl-6 order-xl-4">
+            <a href="https://github.com/willnorris/microformats"
+              >Source code for the Microformats Go Parser</a
+            >
+          </li>
+          <li id="parser-list" class="col-xl-6 order-xl-3">
+            Other Microformats Parser websites:
+            <a href="https://node.microformats.io">Node</a>,
+            <a href="https://php.microformats.io">PHP</a>,
+            <a href="https://python.microformats.io">Python</a>,
+            <a href="https://ruby.microformats.io">Ruby</a>, and
+            <a href="https://rust.microformats.io">Rust</a>.
+          </li>
+          <li class="col-xl-6 order-xl-5">
+            <a href="https://microformats.org/wiki/microformats2#Parsers"
+              >More Microformats parsers</a
+            >
+          </li>
+        </ul>
+        <p class="text-center mt-5 pt-5">
+          <a
+            href="https://github.com/willnorris/microformats/blob/main/LICENSE"
+            rel="license"
+            class="link-secondary link-underline-opacity-25"
+            >MIT</a
+          >
+        </p>
+      </footer>
+
+      <script type="module">
+        const nodeList = document
+          .getElementById("parser-list")
+          .querySelectorAll("a");
+        const values = Array.from(nodeList, (node) => [
+          Math.random(),
+          node.href,
+          node.innerText,
+        ]).toSorted(([v1], [v2]) => v2 - v1);
+        nodeList.forEach((node, ix) => {
+          node.href = values[ix][1];
+          node.innerText = values[ix][2];
+        });
+      </script>
     </div>
-    {{ end }}
-
-    <footer class="mb-5">
-      <ul>
-        <li><a href="https://microformats.io">About Microformats</a></li>
-        <li><a href="https://github.com/willnorris/microformats/tree/master/cmd/gomfweb">Source code for this site</a></li>
-        <li><a href="https://github.com/willnorris/microformats">Source code for the Microformats Go Parser</a></li>
-        <li>
-          Other Microformats Parser websites:
-          <a href="https://node.microformats.io">Node</a>,
-          <a href="https://php.microformats.io">PHP</a>,
-          <a href="https://python.microformats.io">Python</a>, and
-          <a href="https://ruby.microformats.io">Ruby</a>.
-        </li>
-        <li><a href="https://microformats.org/wiki/microformats2#Parsers">More Microformats parsers</a></li>
-      </ul>
-    </footer>
-  </main>
-</body>
+  </body>
 </html>

--- a/cmd/gomfweb/index.html
+++ b/cmd/gomfweb/index.html
@@ -59,8 +59,7 @@
                 name="html"
                 rows="6"
                 class="form-control form-control-lg font-monospace"
-              >
-{{ .HTML }}</textarea>
+              ></textarea>
             </div>
 
             <div class="mb-3">
@@ -74,7 +73,6 @@
                 id="base-url"
                 name="url"
                 type="url"
-                value="{{ .URL }}"
                 class="form-control form-control-lg font-monospace"
               />
             </div>
@@ -82,20 +80,6 @@
             <button type="submit" class="btn btn-lg btn-success">Parse</button>
           </form>
         </section>
-
-        {{ with .JSON }}
-        <section class="mb-5">
-          <label for="json" class="form-label fw-bold">JSON</label>
-          <textarea
-            id="json"
-            name="json"
-            rows="10"
-            class="form-control form-control-lg font-monospace"
-            disabled="disabled"
-          >
-{{ . }}</textarea>
-        </section>
-        {{ end }}
 
         <section class="card mb-5">
           <div class="card-body">

--- a/cmd/gomfweb/main.go
+++ b/cmd/gomfweb/main.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -25,6 +26,18 @@ import (
 )
 
 var addr = flag.String("addr", ":4001", "Address and port to listen on")
+
+func libVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "devel"
+	}
+	v := strings.TrimPrefix(info.Main.Version, "v")
+	if v == "" || v == "(devel)" {
+		return "devel"
+	}
+	return v
+}
 
 func main() {
 	flag.Parse()
@@ -97,13 +110,15 @@ func index(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := struct {
-		HTML string
-		URL  string
-		JSON string
+		HTML       string
+		URL        string
+		JSON       string
+		LibVersion string
 	}{
 		html,
 		u,
 		buf.String(),
+		libVersion(),
 	}
 
 	if err := tpl.Execute(w, data); err != nil {

--- a/cmd/gomfweb/main.go
+++ b/cmd/gomfweb/main.go
@@ -90,14 +90,7 @@ func index(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("error marshaling json: %v", err), http.StatusInternalServerError)
 		}
 
-		if callback := r.FormValue("callback"); callback != "" {
-			_, _ = fmt.Fprintf(w, "%s(%s)", callback, buf.String())
-		} else {
-			w.Header().Set("Content-Type", "application/mf2+json")
-			if _, err := io.Copy(w, buf); err != nil {
-				log.Print(err)
-			}
-		}
+		writeJSON(w, r, buf)
 		return
 	}
 
@@ -107,22 +100,29 @@ func index(w http.ResponseWriter, r *http.Request) {
 		if err := enc.Encode(mf); err != nil {
 			http.Error(w, fmt.Sprintf("error marshaling json: %v", err), http.StatusInternalServerError)
 		}
+		writeJSON(w, r, buf)
+		return
 	}
 
 	data := struct {
-		HTML       string
-		URL        string
-		JSON       string
 		LibVersion string
 	}{
-		html,
-		u,
-		buf.String(),
 		libVersion(),
 	}
 
 	if err := tpl.Execute(w, data); err != nil {
 		log.Print(err)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, r *http.Request, buf *bytes.Buffer) {
+	if callback := r.FormValue("callback"); callback != "" {
+		_, _ = fmt.Fprintf(w, "%s(%s)", callback, buf.String())
+	} else {
+		w.Header().Set("Content-Type", "application/mf2+json")
+		if _, err := io.Copy(w, buf); err != nil {
+			log.Print(err)
+		}
 	}
 }
 


### PR DESCRIPTION
This is based on https://github.com/microformats/microformats-parser-website-python/pull/22.

I am trying to do a refresh of the pages. Partly triggered by the fact that we are using a deprecated CDN to serve an alpha version of Bootstrap today. This takes the front-end design that was done over on Python.

The HTML template is almost byte-for-byte the same as in the PRs I opened on Python, Node, and Rust. The biggest difference is that this does not carry the CC0 license nor does it link to the microformats/microformats-parser-website-go repository.

To bring the behaviour more in line with the other sites, parsing HTML snippets now also loads a raw JSON body rather than displaying anything as part of the parser page.

I will say that I am not a Golang developer, though I have dabbled. I have tried to keep the changes to `main.go` as minimal as possible. So I think these changes should be fine.

If this gets merged, I will make sure to update the dependency over on the microformats/microformats-parser-website-go repository.